### PR TITLE
Update cordova-lib with fix for overwriting jar file with links

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,8 +4,8 @@
   "dependencies": {
     "cordova-lib": {
       "version": "5.3.2",
-      "from": "git+https://github.com/Icenium/cordova-lib.git#0b6205b0296584598d33f8142156b54ceaf0aa39",
-      "resolved": "git+https://github.com/Icenium/cordova-lib.git#0b6205b0296584598d33f8142156b54ceaf0aa39",
+      "from": "git+https://github.com/Icenium/cordova-lib.git#a58c028e4388b75df8175df686ee36e88d3a0898",
+      "resolved": "git+https://github.com/Icenium/cordova-lib.git#a58c028e4388b75df8175df686ee36e88d3a0898",
       "dependencies": {
         "aliasify": {
           "version": "1.7.2",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "engineStrict":true,
   "dependencies": {
-    "cordova-lib": "git+https://github.com/Icenium/cordova-lib#0b6205b0296584598d33f8142156b54ceaf0aa39",
+    "cordova-lib": "git+https://github.com/Icenium/cordova-lib#a58c028e4388b75df8175df686ee36e88d3a0898",
     "nopt": "1.0.9",
     "q": "1.0.1"
   },


### PR DESCRIPTION
Get commit "Overwrite destination in copyFile with symlinks
copyFile should behave consistently when using symlinking and when actually copying the file.
Since fs.symlinkSym throws an error when the destination exists, we now check and delete the file if it is already present."

 @Icenium/core 
